### PR TITLE
List to Map version of kafka-topic-creation command

### DIFF
--- a/helm/templates/kafka-topic-creation-hook.yaml
+++ b/helm/templates/kafka-topic-creation-hook.yaml
@@ -37,25 +37,26 @@ spec:
             - "/bin/bash"
             - "-cex"
             - |
-            {{- range $topic := .Values.kafka.topics }}
+            {{- range $topicName, $configs := $.Values.kafka.topics }}
               /opt/kafka/bin/kafka-topics.sh --create \
               --if-not-exists \
               --zookeeper {{ $.Values.zookeeper.address | quote }} \
-              --topic {{ $topic.name | quote }} \
-            {{- range $topic.configs }}
-              --config {{ . | quote }} \
+              --topic {{ $topicName | quote }} \
+            {{- range $configName, $configValue := $configs.configs }}
+              --config "{{$configName}}={{int $configValue }}"  \
             {{- end }}
-              --replication-factor {{ $topic.replicationFactor | quote }} \
-              --partitions {{ $topic.partitions | quote }}
-            {{- if $topic.configs }}
+              --replication-factor {{ $configs.replicationFactor | quote }} \
+              --partitions {{ $configs.partitions | quote }}
+            {{- if $configs.configs }}
+            {{- $comma := false }}
               /opt/kafka/bin/kafka-configs.sh --alter \
               --zookeeper {{ $.Values.zookeeper.address | quote }} \
               --add-config \
-              {{ range $i, $c := $topic.configs }}{{ if $i }}{{ printf "," }}{{ end }}{{ $c | quote }}{{ end }} \
+              {{ range $i, $c := $configs.configs }}{{ if $comma }}{{ printf "," }}{{ end }}"{{ $i }}={{ int $c }}"{{- $comma = true -}}{{ end }} \
               --entity-type topics \
-              --entity-name {{ $topic.name | quote }}
-            {{- end }}
-            {{- end }}
+              --entity-name {{ $topicName | quote }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Currently we have a list implementation of the the various kafka-topics which needs to be generated. This makes changing certain values of the topic difficult since list are not merged in Helm. So migration of the list to map should be done as maps support merging.