### PR TITLE
add a configmap in helm chart

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.configMap.enabled }}
+apiVersion: batch/v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.jobName }}
+  labels:
+    release: {{ .Release.Name }}
+data:
+  key: value
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -44,3 +44,6 @@ kafka:
   topics: {}
 
 skipUpdate: false
+
+configMap:
+  enabled: false


### PR DESCRIPTION
This PR will add a configmap as a workaround to `Error: no objects visited` error while deploying the helm chart.