### PR TITLE
chore: check list of existing topics  before fetching their configs

### DIFF
--- a/kafka-topic-creator/src/main/go/main.go
+++ b/kafka-topic-creator/src/main/go/main.go
@@ -198,8 +198,6 @@ func main() {
 		}
 	}
 
-	existingTopicConfigs := GetTopicConfigs(a, topicList)
-
 	log.Printf("Number of new topics: %d\n", len(newTopics))
 	if len(newTopics) > 0 {
 		CreateTopics(a, newTopics)
@@ -207,6 +205,7 @@ func main() {
 
 	log.Printf("Number of existing topics: %d\n", len(existingTopics))
 	if len(existingTopics) > 0 {
+		existingTopicConfigs := GetTopicConfigs(a, existingTopics)
 		updatedTopics := make([]kafka.ConfigResource, 0, len(existingTopics))
 		for _, t := range existingTopics {
 			log.Printf("checking config for topic %s\n", t)


### PR DESCRIPTION
fixes issue while creating topics in a new kafka cluster:
```
2023/10/05 10:57:02 configpath: /opt/kafka/config.yaml
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/confluentinc/confluent-kafka-go/v2/kafka.(*AdminClient).DescribeConfigs.func6(0x200?, 0x21974a0?, 0xc0001f7d30?, 0x1?)
	/go/pkg/mod/github.com/confluentinc/confluent-kafka-go/v2@v2.1.0/kafka/adminapi.go:1463 +0x125
github.com/confluentinc/confluent-kafka-go/v2/kafka.(*AdminClient).DescribeConfigs(0xc0001f7d10, {0xa08948, 0xd01c80}, {0xd01c80, 0x0, 0x1?}, {0xc0000c5940, 0x1, 0x7ff70407c140?})
	/go/pkg/mod/github.com/confluentinc/confluent-kafka-go/v2@v2.1.0/kafka/adminapi.go:1466 +0x647
main.GetTopicConfigs(0xc0000c5db8?, {0xd01c80, 0x0, 0xe?})
	/opt/main.go:60 +0x23a
main.main()
	/opt/main.go:179 +0x93f
```