### PR TITLE
fix: kstreams-app-version-checker container not defined

### DIFF
--- a/kstreams-app-version-checker/run.sh
+++ b/kstreams-app-version-checker/run.sh
@@ -64,7 +64,7 @@ for workload in $WORKLOADS; do
     continue
   fi
 
-  current_version=$(kubectl -n $NAMESPACE get $type $name  -o json | jq -r --arg container "$container" '.spec.template.spec.containers[] | select(.name==$container) | .image' | awk -F':' '{print $2}')
+  current_version=$(kubectl -n $NAMESPACE get $type $name  -o json | jq -r --arg container "$container" '.spec.template.spec.containers[] | select(.name=="$container") | .image' | awk -F':' '{print $2}')
   echo "current_version: $current_version"
 
   if [ -z "$current_version" ]; then


### PR DESCRIPTION
## Description
When container name has hypen present in it, fetching current version fails with the following error
```
jq: error: sample/0 is not defined at <top-level>, line 1:
.spec.template.spec.containers[] | select(.name==sample-container) | .image
jq: error: container/0 is not defined at <top-level>, line 1:
.spec.template.spec.containers[] | select(.name==sample-container) | .image
jq: 2 compile errors
```

### Testing
deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules