### PR TITLE
ASP-1893: Fix security vulnerabilities in kstreams-app-version-checker and kafka-topic-creator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("org.hypertrace.repository-plugin") version "0.4.0"
-  id("org.hypertrace.docker-plugin") version "0.9.9"
-  id("org.hypertrace.docker-publish-plugin") version "0.9.9"
+  id("org.hypertrace.repository-plugin") version "0.5.0"
+  id("org.hypertrace.docker-plugin") version "0.11.3"
+  id("org.hypertrace.docker-publish-plugin") version "0.11.3"
 }

--- a/kafka-topic-creator/Dockerfile
+++ b/kafka-topic-creator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7 AS builder
+FROM golang:1.26.2 AS builder
 COPY src/main/go /opt
 WORKDIR /opt
 

--- a/kafka-topic-creator/src/main/go/go.mod
+++ b/kafka-topic-creator/src/main/go/go.mod
@@ -1,6 +1,6 @@
 module hypertrace.org/kafka-topic-creator
 
-go 1.22.7
+go 1.26.2
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.5.3

--- a/kstreams-app-version-checker/Dockerfile
+++ b/kstreams-app-version-checker/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.20
+FROM alpine:3.23
 
-ENV KUBECTL_VERSION=v1.28.14
+ENV KUBECTL_VERSION=v1.35.4
 
 RUN apk add curl jq --no-cache && \
     curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \


### PR DESCRIPTION
## Summary

Fixes critical and high severity CVEs in both images built from this repo by upgrading base images, dependencies, and build toolchain.

### kstreams-app-version-checker
- **Alpine**: 3.20 → 3.23 (patches OpenSSL to 3.3.7+ and curl to 8.14.1+)
- **kubectl**: v1.28.14 → v1.35.4 (latest stable, compiled with patched Go)

### kafka-topic-creator
- **Go**: 1.22.7 → 1.26.2 (latest stable, fixes Go stdlib CVEs)

### Build plugins
- `org.hypertrace.repository-plugin`: 0.4.0 → 0.5.0
- `org.hypertrace.docker-plugin`: 0.9.9 → 0.11.3
- `org.hypertrace.docker-publish-plugin`: 0.9.9 → 0.11.3

### CVEs Addressed

| Dependency | CVEs | Severity |
|---|---|---|
| Go stdlib (kubectl + kafka-topic-creator) | CVE-2025-68121 | CRITICAL (10.0) |
| Go stdlib (kubectl + kafka-topic-creator) | CVE-2025-61729, CVE-2025-61726, CVE-2025-61723, CVE-2025-58187, CVE-2025-58188, CVE-2025-47907, CVE-2026-25679, CVE-2026-32280, CVE-2026-32282 | HIGH |
| OpenSSL (Alpine) | CVE-2025-15467, CVE-2026-31790, CVE-2026-28390, CVE-2026-28389, CVE-2026-28388, CVE-2025-9230, CVE-2025-69421, CVE-2025-69420, CVE-2025-69419 | HIGH |
| curl (Alpine) | CVE-2025-9086, CVE-2025-5399 | HIGH |

### Follow-up

After this is merged and new image versions are published, update `helm/Chart.yaml` in the consuming repos (activity-event-service, api-anomaly-detection, api-naming, insights) to reference the new chart version.

Jira: [ASP-1893](https://harness.atlassian.net/browse/ASP-1893)