### PR TITLE
ASP-1893: Migrate plugin repo from JFrog to Google Artifact Registry

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,12 +2,12 @@ pluginManagement {
   repositories {
     mavenLocal()
     gradlePluginPortal()
-    maven("https://hypertrace.jfrog.io/artifactory/maven")
+    maven("https://us-maven.pkg.dev/hypertrace-repos/maven")
   }
 }
 
 plugins {
-  id("org.hypertrace.version-settings") version "0.2.0"
+  id("org.hypertrace.version-settings") version "0.3.0"
 }
 
 rootProject.name = "kafka-topic-creator"


### PR DESCRIPTION
## Summary
- Migrate plugin repository from `hypertrace.jfrog.io/artifactory/maven` to `us-maven.pkg.dev/hypertrace-repos/maven`
- Bump `org.hypertrace.version-settings` plugin from `0.2.0` to `0.3.0`

This fixes the publish workflow failure where JFrog returns a corrupted POM for version-settings-plugin 0.2.0:
```
[Fatal Error] org.hypertrace.version-settings.gradle.plugin-0.2.0.pom:2:10: Already seen doctype.
```

Aligns with other hypertrace repos that have already migrated (document-store, kafka-streams-framework, data-model, etc.).

## Context
- Failed publish run: https://github.com/hypertrace/kafka-topic-creator/actions/runs/24549886625
- After this merges, a new release needs to be created to publish the `1.0.17` images/charts

## Test plan
- [ ] CI build passes
- [ ] After merge, create release and verify publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)